### PR TITLE
macOS/clang and Linux/intel port

### DIFF
--- a/make/vm-x86-gfortran-clang.mk
+++ b/make/vm-x86-gfortran-clang.mk
@@ -1,0 +1,90 @@
+# Platform specific settings
+#-------------------------------------------------------------------------------
+
+# Make
+#-----
+# Make command
+MAKE=make
+
+# Fortran
+#--------
+FPP=cpp
+# Any flags required to make the preprocessor function correctly
+FPPFLAGS_BASE=-C -P -undef -nostdinc
+# Any other flags (to be passed to all preprocessing commands)
+FPPFLAGS_EXTRA=-Wall -Wtraditional -Werror -fdiagnostics-show-option
+# IEEE Arithmetic
+SHUM_HAS_IEEE_ARITHMETIC ?= false
+ifeq (${SHUM_HAS_IEEE_ARITHMETIC}, true)
+FPPFLAGS_IEEE=-DHAS_IEEE_ARITHMETIC
+else ifeq (${SHUM_HAS_IEEE_ARITHMETIC}, false)
+FPPFLAGS_IEEE=
+endif
+SHUM_EVAL_NAN_BY_BITS ?= true
+ifeq (${SHUM_EVAL_NAN_BY_BITS}, true)
+FPPFLAGS_ENBB=-DEVAL_NAN_BY_BITS
+else ifeq (${SHUM_EVAL_NAN_BY_BITS}, false)
+FPPFLAGS_ENBB=
+endif
+SHUM_EVAL_DENORMAL_BY_BITS ?= true
+ifeq (${SHUM_EVAL_DENORMAL_BY_BITS}, true)
+FPPFLAGS_EDBB=-DEVAL_DENORMAL_BY_BITS
+else ifeq (${SHUM_EVAL_DENORMAL_BY_BITS}, false)
+FPPFLAGS_EDBB=
+endif
+# Combine the preprocessor flags
+FPPFLAGS=${FPPFLAGS_BASE} ${FPPFLAGS_IEEE} ${FPPFLAGS_ENBB} ${FPPFLAGS_EDBB} ${FPPFLAGS_EXTRA}
+# Compiler command
+FC=gfortran
+# Precision flags (passed to all compilation commands)
+FCFLAGS_PREC=
+# Flag used to set OpenMP (passed to all compilation commands)
+FCFLAGS_OPENMP=
+# Flag used to unset OpenMP (passed to all compilation commands)
+FCFLAGS_NOOPENMP=
+# Any other flags (to be passed to all compilation commands)
+FCFLAGS_EXTRA=-std=f2008ts -pedantic -pedantic-errors -fno-range-check
+# Flag used to set PIC (Position-independent-code; required by dynamic lib
+# and so will only be passed to compile objects destined for the dynamic lib)
+FCFLAGS_PIC=-fPIC
+# Flags used to toggle the building of a dynamic (shared) library
+FCFLAGS_SHARED=-shared
+# Flags used for compiling a dynamically linked test executable; in some cases
+# control of this is argument order dependent - for these cases the first
+# variable will be inserted before the link commands and the second will be
+# inserted afterwards
+FCFLAGS_DYNAMIC=
+FCFLAGS_DYNAMIC_TRAIL=-Wl,-rpath=${LIBDIR_OUT}/lib
+# Flags used for compiling a statically linked test executable (following the
+# same rules as the dynamic equivalents - see above comment)
+FCFLAGS_STATIC=-Wl,-Bstatic
+FCFLAGS_STATIC_TRAIL=-Wl,-Bdynamic
+
+# C
+#--
+# Compiler command
+CC=clang
+# Precision flags (passed to all compilation commands)
+CCFLAGS_PREC=
+# Flag used to set OpenMP (passed to all compilation commands)
+SHUM_USE_C_OPENMP_VIA_THREAD_UTILS ?= false
+CCFLAGS_OPENMP=
+# Flag used to unset OpenMP (passed to all compilation commands)
+CCFLAGS_NOOPENMP=-Wno-unknown-pragmas
+# Any other flags (to be passed to all compilation commands)
+CCFLAGS_EXTRA=
+# Flag used to set PIC (Position-independent-code; required by dynamic lib
+# and so will only be passed to compile objects destined for the dynamic lib)
+CCFLAGS_PIC=-fPIC
+
+# Archiver
+#---------
+# Archiver command
+AR=ar -rc
+
+# Set the name of this platform; this will be included as the name of the
+# top-level directory in the build
+PLATFORM=vm-x86-clang-gcc
+
+# Proceed to include the rest of the common makefile
+include Makefile

--- a/make/vm-x86-gfortran-clang.mk
+++ b/make/vm-x86-gfortran-clang.mk
@@ -84,7 +84,7 @@ AR=ar -rc
 
 # Set the name of this platform; this will be included as the name of the
 # top-level directory in the build
-PLATFORM=vm-x86-clang-gcc
+PLATFORM=vm-x86-gfortran-clang
 
 # Proceed to include the rest of the common makefile
 include Makefile

--- a/make/vm-x86-ifort-icc.mk
+++ b/make/vm-x86-ifort-icc.mk
@@ -1,0 +1,90 @@
+# Platform specific settings
+#-------------------------------------------------------------------------------
+
+# Make
+#-----
+# Make command
+MAKE=make
+
+# Fortran
+#--------
+FPP=cpp
+# Any flags required to make the preprocessor function correctly
+FPPFLAGS_BASE=-C -P -undef -nostdinc
+# Any other flags (to be passed to all preprocessing commands)
+FPPFLAGS_EXTRA=-Wall -Wtraditional -Werror
+# IEEE Arithmetic
+SHUM_HAS_IEEE_ARITHMETIC ?= false
+ifeq (${SHUM_HAS_IEEE_ARITHMETIC}, true)
+FPPFLAGS_IEEE=-DHAS_IEEE_ARITHMETIC
+else ifeq (${SHUM_HAS_IEEE_ARITHMETIC}, false)
+FPPFLAGS_IEEE=
+endif
+SHUM_EVAL_NAN_BY_BITS ?= true
+ifeq (${SHUM_EVAL_NAN_BY_BITS}, true)
+FPPFLAGS_ENBB=-DEVAL_NAN_BY_BITS
+else ifeq (${SHUM_EVAL_NAN_BY_BITS}, false)
+FPPFLAGS_ENBB=
+endif
+SHUM_EVAL_DENORMAL_BY_BITS ?= true
+ifeq (${SHUM_EVAL_DENORMAL_BY_BITS}, true)
+FPPFLAGS_EDBB=-DEVAL_DENORMAL_BY_BITS
+else ifeq (${SHUM_EVAL_DENORMAL_BY_BITS}, false)
+FPPFLAGS_EDBB=
+endif
+# Combine the preprocessor flags
+FPPFLAGS=${FPPFLAGS_BASE} ${FPPFLAGS_IEEE} ${FPPFLAGS_ENBB} ${FPPFLAGS_EDBB} ${FPPFLAGS_EXTRA}
+# Compiler command
+FC=ifort
+# Precision flags (passed to all compilation commands)
+FCFLAGS_PREC=
+# Flag used to set OpenMP (passed to all compilation commands)
+FCFLAGS_OPENMP=-qopenmp
+# Flag used to unset OpenMP (passed to all compilation commands)
+FCFLAGS_NOOPENMP=
+# Any other flags (to be passed to all compilation commands)
+FCFLAGS_EXTRA=-std08
+# Flag used to set PIC (Position-independent-code; required by dynamic lib
+# and so will only be passed to compile objects destined for the dynamic lib)
+FCFLAGS_PIC=-fPIC
+# Flags used to toggle the building of a dynamic (shared) library
+FCFLAGS_SHARED=-shared
+# Flags used for compiling a dynamically linked test executable; in some cases
+# control of this is argument order dependent - for these cases the first
+# variable will be inserted before the link commands and the second will be
+# inserted afterwards
+FCFLAGS_DYNAMIC=
+FCFLAGS_DYNAMIC_TRAIL=-Wl,-rpath=${LIBDIR_OUT}/lib
+# Flags used for compiling a statically linked test executable (following the
+# same rules as the dynamic equivalents - see above comment)
+FCFLAGS_STATIC=-Wl,-Bstatic
+FCFLAGS_STATIC_TRAIL=-Wl,-Bdynamic
+
+# C
+#--
+# Compiler command
+CC=icc
+# Precision flags (passed to all compilation commands)
+CCFLAGS_PREC=
+# Flag used to set OpenMP (passed to all compilation commands)
+SHUM_USE_C_OPENMP_VIA_THREAD_UTILS ?= false
+CCFLAGS_OPENMP=-qopenmp
+# Flag used to unset OpenMP (passed to all compilation commands)
+CCFLAGS_NOOPENMP=-Wno-unknown-pragmas
+# Any other flags (to be passed to all compilation commands)
+CCFLAGS_EXTRA=-restrict
+# Flag used to set PIC (Position-independent-code; required by dynamic lib
+# and so will only be passed to compile objects destined for the dynamic lib)
+CCFLAGS_PIC=-fPIC
+
+# Archiver
+#---------
+# Archiver command
+AR=ar -rc
+
+# Set the name of this platform; this will be included as the name of the
+# top-level directory in the build
+PLATFORM=vm-x86-ifort-icc
+
+# Proceed to include the rest of the common makefile
+include Makefile

--- a/shum_byteswap/src/Makefile
+++ b/shum_byteswap/src/Makefile
@@ -36,7 +36,7 @@ c_shum_byteswap_PIC.o: c_shum_byteswap.c c_shum_byteswap.h c_shum_byteswap_opt.h
 f_shum_byteswap_PIC.o: f_shum_byteswap.f90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
-libshum_byteswap.so: c_shum_byteswap_PIC.o f_shum_byteswap_PIC.o ${VERSION_OBJECTS_PIC}
+libshum_byteswap.so: c_shum_byteswap_PIC.o f_shum_byteswap_PIC.o ${LIBDIR_OUT}/lib/libshum_string_conv.so ${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 
 # Cleanup

--- a/shum_byteswap/src/c_shum_byteswap_opt.h
+++ b/shum_byteswap/src/c_shum_byteswap_opt.h
@@ -211,7 +211,15 @@
 #endif
 
 #if defined(C_USE_BSWAP_BYTESWAP_H)
+#if defined(__APPLE__)
+// Mac OS X / Darwin features
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#else
 #include <byteswap.h>
+#endif
 #endif
 
 #if defined(C_USE_BSWAP_64_BITSHIFT)

--- a/shum_data_conv/src/Makefile
+++ b/shum_data_conv/src/Makefile
@@ -36,7 +36,7 @@ c_shum_data_conv_PIC.o: c_shum_data_conv.c c_shum_data_conv.h ${COMMON_DIR}/c_sh
 f_shum_data_conv_PIC.o: f_shum_data_conv.f90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
-libshum_data_conv.so: c_shum_data_conv_PIC.o f_shum_data_conv_PIC.o ${VERSION_OBJECTS_PIC}
+libshum_data_conv.so: c_shum_data_conv_PIC.o f_shum_data_conv_PIC.o ${LIBDIR_OUT}/lib/libshum_string_conv.so ${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 
 # Cleanup

--- a/shum_fieldsfile/src/Makefile
+++ b/shum_fieldsfile/src/Makefile
@@ -56,7 +56,10 @@ f_shum_stashmaster_PIC.o: f_shum_stashmaster.f90
 libshum_fieldsfile.so: \
 	f_shum_fieldsfile_PIC.o f_shum_lookup_indices_PIC.o \
 	f_shum_fixed_length_header_indices_PIC.o \
-	f_shum_stashmaster_PIC.o ${VERSION_OBJECTS_PIC}
+	f_shum_stashmaster_PIC.o \
+	${LIBDIR_OUT}/lib/libshum_byteswap.so \
+	${LIBDIR_OUT}/lib/libshum_string_conv.so \
+	${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 
 # Cleanup

--- a/shum_fieldsfile_class/src/Makefile
+++ b/shum_fieldsfile_class/src/Makefile
@@ -44,7 +44,10 @@ f_shum_ff_status_PIC.o: f_shum_ff_status.f90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
 libshum_fieldsfile_class.so: \
-	f_shum_file_PIC.o f_shum_field_PIC.o f_shum_ff_status_PIC.o ${VERSION_OBJECTS_PIC}
+	f_shum_file_PIC.o f_shum_field_PIC.o f_shum_ff_status_PIC.o \
+	${LIBDIR_OUT}/lib/libshum_fieldsfile.so \
+	${LIBDIR_OUT}/lib/libshum_wgdos_packing.so \
+	${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 
 # Cleanup

--- a/shum_number_tools/src/Makefile
+++ b/shum_number_tools/src/Makefile
@@ -17,13 +17,13 @@ include ${COMMON_DIR}/Makefile-version
 
 # Static library - uses archiver to create library
 #-------------------------------------------------------------------------------
-f_shum_is_inf.o: f_shum_is_inf.f90
+f_shum_is_inf.o: f_shum_is_inf.F90
 	${FC} ${FCFLAGS} -c -I${LIBDIR_OUT}/include $<
 
-f_shum_is_nan.o: f_shum_is_nan.f90
+f_shum_is_nan.o: f_shum_is_nan.F90
 	${FC} ${FCFLAGS} -c -I${LIBDIR_OUT}/include $<
 
-f_shum_is_denormal.o: f_shum_is_denormal.f90
+f_shum_is_denormal.o: f_shum_is_denormal.F90
 	${FC} ${FCFLAGS} -c -I${LIBDIR_OUT}/include $<
 
 libshum_number_tools.a: f_shum_is_inf.o f_shum_is_nan.o f_shum_is_denormal.o \
@@ -34,13 +34,13 @@ libshum_number_tools.a: f_shum_is_inf.o f_shum_is_nan.o f_shum_is_denormal.o \
 # are suffixed to keep them separate to the above (since the dynamic library
 # required position-independent-code flags whilst the static version does not)
 #-------------------------------------------------------------------------------
-f_shum_is_inf_PIC.o: f_shum_is_inf.f90
+f_shum_is_inf_PIC.o: f_shum_is_inf.F90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
-f_shum_is_nan_PIC.o: f_shum_is_nan.f90
+f_shum_is_nan_PIC.o: f_shum_is_nan.F90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
-f_shum_is_denormal_PIC.o: f_shum_is_denormal.f90
+f_shum_is_denormal_PIC.o: f_shum_is_denormal.F90
 	${FC} ${FCFLAGS} ${FCFLAGS_PIC} -c -I${LIBDIR_OUT}/include $< -o $@
 
 libshum_number_tools.so: f_shum_is_inf_PIC.o f_shum_is_nan_PIC.o f_shum_is_denormal_PIC.o \
@@ -51,9 +51,4 @@ libshum_number_tools.so: f_shum_is_inf_PIC.o f_shum_is_nan_PIC.o f_shum_is_denor
 #-------------------------------------------------------------------------------
 .PHONY: clean
 clean:
-	rm -f *.o *.mod *.so *.a *.f90 ${VERSION_CLEAN}
-
-# Preprocess targets
-#--------------------------------------------------------------------------------
-%.f90: %.F90
-	${FPP} ${FPPFLAGS} $< -o $@
+	rm -f *.o *.mod *.so *.a ${VERSION_CLEAN}

--- a/shum_spiral_search/src/Makefile
+++ b/shum_spiral_search/src/Makefile
@@ -42,6 +42,7 @@ c_shum_spiral_search_PIC.o: c_shum_spiral_search.f90 f_shum_spiral_search_PIC.o
 libshum_spiral_search.so: \
 	f_shum_spiral_search_PIC.o \
 	c_shum_spiral_search_PIC.o \
+	${LIBDIR_OUT}/lib/libshum_string_conv.so \
 	${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 

--- a/shum_wgdos_packing/src/Makefile
+++ b/shum_wgdos_packing/src/Makefile
@@ -42,6 +42,7 @@ c_shum_wgdos_packing_PIC.o: c_shum_wgdos_packing.f90 f_shum_wgdos_packing_PIC.o
 libshum_wgdos_packing.so: \
 	f_shum_wgdos_packing_PIC.o \
 	c_shum_wgdos_packing_PIC.o \
+	${LIBDIR_OUT}/lib/libshum_string_conv.so \
 	${VERSION_OBJECTS_PIC}
 	${FC} ${FCFLAGS_SHARED} ${FCFLAGS} ${FCFLAGS_PIC} $^ -o $@
 


### PR DESCRIPTION
@metomi I ported your public shumlib master branch to macOS using clang+gfortran. There are a few changes that I would like to contribute back, hopefully they all work for you and your team.

Changes:
- I created a second make include file for clang+gfortran, turning off OpenMP (because clang natively doesn't support OpenMP).
- I had to add shared libraries that are dependencies for other code into several gnu makefiles.
- I changed the two-step compiling (preprocess `.F90` to `.f90`, then compile) into a one-step process, because macOS has a psedo case-sensitive filesystem and the CPP step would "replace" the `.F90` file with the preprocessed `.f90` file.
- I added a workaround for the byteswap code for macOS to `shum_byteswap/src/c_shum_byteswap_opt.h`. This will be ignored on non-Apple systems.

Update 2022/06/14: also added Linux/Intel port